### PR TITLE
ci: add additional trigger for helm release

### DIFF
--- a/.github/workflows/helm-chart-release.yml
+++ b/.github/workflows/helm-chart-release.yml
@@ -7,6 +7,11 @@ on:
     paths:
       - 'charts/**'
 
+  workflow_run:
+    workflows: ["Generate Manifests"]
+    types:
+      - completed
+
 jobs:
   release:
     permissions:


### PR DESCRIPTION
Add additional trigger for helm release

```
on:
  push:
    branches:
      - main
    paths:
      - 'charts/**'

  workflow_run:
    workflows: ["Generate Manifests"]
    types:
      - completed
```

so that the pipeline will run on manual changes to `charts/**` OR after `Generate Manifests` pipeline runs.